### PR TITLE
Target stable channel, add build job, more features usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-vs:
+    name: Build VapourSynth
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install VapourSynth
+        uses: rlaphoenix/install-vapoursynth-action@v2.1.1
+        with:
+          version: 66
+          cache: true
+
   coverage:
+    needs: [build-vs]
     name: Code Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -20,6 +32,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Install VapourSynth
+        uses: rlaphoenix/install-vapoursynth-action@v2.1.1
+        with:
+          version: 66
+          cache: true
       - name: Install Rust
         run: rustup update nightly
       - name: Install cargo-llvm-cov
@@ -40,7 +57,7 @@ jobs:
       - name: Generate code coverage
         run: cargo +nightly llvm-cov nextest
           --all-features --workspace
-          --ignore-filename-regex jpegxl-sys/
+          --ignore-filename-regex vapoursynth-sys/
           --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -50,6 +67,7 @@ jobs:
           fail_ci_if_error: true
 
   sanitizer:
+    needs: [build-vs]
     name: Sanitizers
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -57,6 +75,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Install VapourSynth
+        uses: rlaphoenix/install-vapoursynth-action@v2.1.1
+        with:
+          version: 66
+          cache: true
       - name: Install Rust
         run: rustup update nightly
       - name: Add rust-src
@@ -118,3 +141,17 @@ jobs:
         run: rustup update stable
       - name: Format check
         run: cargo fmt --all -- --check
+
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      - run: cargo check --all --all-features --all-targets
+      - run: cargo build

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/vapoursynth4-rs/src/api.rs
+++ b/vapoursynth4-rs/src/api.rs
@@ -24,6 +24,7 @@ pub(crate) fn api() -> &'static ffi::VSAPI {
 /// # Errors
 ///
 /// Return [`ApiNotFound`] if the requested API is not found.
+#[cfg(feature = "link-library")]
 pub fn set_api_default() -> Result<(), ApiNotFound> {
     let ptr = unsafe { ffi::getVapourSynthAPI(ffi::VAPOURSYNTH_API_VERSION) };
     if ptr.is_null() {
@@ -42,6 +43,7 @@ pub fn set_api_default() -> Result<(), ApiNotFound> {
 /// # Errors
 ///
 /// Return [`ApiNotFound`] if the requested API is not found.
+#[cfg(feature = "link-library")]
 pub fn set_api(major: u16, minor: u16) -> Result<(), ApiNotFound> {
     let version = ffi::vs_make_version(major, minor);
     let ptr = unsafe { ffi::getVapourSynthAPI(version) };

--- a/vapoursynth4-sys/README.md
+++ b/vapoursynth4-sys/README.md
@@ -20,9 +20,8 @@ All VapourSynth and VSScript API versions starting with 4.0 are supported.
 By default, the crates use the latest API version available.  To use a specific version, 
 disable the default feature and enable the corresponding Cargo feature:
 
-- `vapoursynth-api-40` for VapourSynth API 4.0 (R55)
-- `vsscript-api-40` for VSScript API 4.0
-- `vsscript-api-41` for VSScript API 4.1
+- `vsscript` for VSScript API 4.0
+- `vsscript-41` for VSScript API 4.1
 
 ## Building
 

--- a/vapoursynth4-sys/build.rs
+++ b/vapoursynth4-sys/build.rs
@@ -20,6 +20,8 @@ fn main() {
 
         // Handle linking to VapourSynth libs.
         println!("cargo:rustc-link-lib=vapoursynth");
+
+        #[cfg(any(feature = "vscript", feature = "vsscript-41"))]
         println!("cargo:rustc-link-lib=vapoursynth-script");
     }
 }

--- a/vapoursynth4-sys/src/lib.rs
+++ b/vapoursynth4-sys/src/lib.rs
@@ -17,6 +17,8 @@ mod vsscript;
 
 pub use crate::constants::*;
 pub use crate::vs::*;
+
+#[cfg(any(feature = "vscript", feature = "vsscript-41"))]
 pub use crate::vsscript::*;
 
 macro_rules! opaque_struct {

--- a/vapoursynth4-sys/src/vsscript.rs
+++ b/vapoursynth4-sys/src/vsscript.rs
@@ -28,8 +28,6 @@
 //! If `libvapoursynth-script` is loaded with `dlopen()`, the `RTLD_GLOBAL` flag must be used.
 //! If not, Python won’t be able to import binary modules. This is due to Python’s design.
 
-#![cfg(feature = "vsscript")]
-
 use std::ffi::*;
 
 use super::*;


### PR DESCRIPTION
This started with just a small fix to building on nightly and turned into a bit more, sorry. I separated each thing into individual commits to make it easier to review.

So on 1.79.0-nightly (3a36386dc 2024-04-25), there's the follow build error:

```
error: `std::ptr::mut_ptr::<impl *mut T>::copy_from_nonoverlapping` is not yet stable as a const fn
   --> vapoursynth4-sys\src\helper.rs:179:13
    |
179 |             dstp.copy_from_nonoverlapping(srcp, row_size * height);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(const_intrinsic_copy)]` to the crate attributes to enable
```

`#![feature]` can only be used on nightly though, so adding this would make the project not build on stable or beta. ~~I'm not sure what's desired here, but since most of the CI jobs were using nightly, I'm assuming that's what we want so I added the `#![feature]`.~~

I then added a `rust-toolchain.toml` to indicate to rustup that this project requires ~~nightly~~ stable. Should help future developers know what toolchain to install.

---

Then come the less-related changes that I should've split out, and I still can if we want, but:

I put `set_api_default()` and `set_api()` behind the `link-library` feature, which I believe fixes https://github.com/inflation/vapoursynth4-rs/issues/2, or at least it does for me.

I also added a build job to verify everything builds properly on ~~nightly~~ stable.

The coverage and sanitizer jobs are unfortunately gonna fail. They try to link to VS (because they use `--all-features`, enabling `link-library`), so I added rlaphoenix/install-vapoursynth-action to install VS, but that action builds VS without VSScript so linking to `vapoursynth-script` will fail. I couldn't find an easy way to recursively disable default features (because we need to disable `vsscript` from sample-plugin > vapoursynth4-rs > vapoursynth4-sys), so I'm just gonna leave the jobs alone.