### PR TITLE
refactor: simplify maps to just `Map` and `MapRef`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           submodules: recursive
       - name: Install Rust
         run: rustup update stable
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache
         with:
           path: |

--- a/sample-plugin/src/dither.rs
+++ b/sample-plugin/src/dither.rs
@@ -1,0 +1,120 @@
+use std::ffi::{c_void, CStr};
+
+use const_str::cstr;
+use vapoursynth4_rs::{
+    core::CoreRef,
+    frame::{FrameContext, VideoFrame},
+    key,
+    map::{AppendMode, Map, MapRef, Value},
+    node::{
+        ActivationReason, Dependencies, Filter, FilterDependency, Node, RequestPattern, VideoNode,
+    },
+};
+
+/// An example filter that dithers the input clip to the specified bit depth
+/// using the fmtconv plugin. This demonstrates how to invoke other plugins.
+pub(crate) struct DitherFilter {
+    /// Input node.
+    node: VideoNode,
+}
+
+impl Filter for DitherFilter {
+    type Error = &'static CStr;
+    type FrameType = VideoFrame;
+    type FilterData = ();
+
+    fn create(
+        input: &MapRef,
+        output: &mut MapRef,
+        _data: Option<Box<Self::FilterData>>,
+        mut core: CoreRef,
+    ) -> Result<(), Self::Error> {
+        let Ok(node) = input.get_video_node(key!("clip"), 0) else {
+            return Err(cstr!("Failed to get clip"));
+        };
+
+        // Input parameters.
+        let bits = input.get_int_saturated(key!("bits"), 0).unwrap_or(16);
+
+        // Use fmtconv to dither to the desired bit depth.
+        let Some(fmtc_plugin) = core.get_plugin_by_namespace(cstr!("fmtc")) else {
+            return Err(cstr!("Failed to find the fmtconv plugin."));
+        };
+        let mut args = Map::new();
+        args.set(
+            key!("clip"),
+            Value::VideoNode(node.clone()),
+            AppendMode::Replace,
+        )
+        .unwrap();
+        args.set(key!("bits"), Value::Int(bits as i64), AppendMode::Replace)
+            .unwrap();
+        args.set(key!("dmode"), Value::Int(8), AppendMode::Replace)
+            .unwrap();
+        let ret = fmtc_plugin.invoke(cstr!("bitdepth"), &args);
+        let Ok(dithered_node) = ret.get_video_node(key!("clip"), 0) else {
+            return Err(cstr!("Failed to dither the clip."));
+        };
+
+        // Update output info to reflect the new bit depth.
+        let mut vi = node.info().clone();
+        vi.format = core.query_video_format(
+            vi.format.color_family,
+            vi.format.sample_type,
+            bits,
+            vi.format.sub_sampling_w,
+            vi.format.sub_sampling_h,
+        );
+
+        let mut filter = DitherFilter {
+            node: dithered_node,
+        };
+
+        let deps = [FilterDependency {
+            source: filter.node.as_mut_ptr(),
+            request_pattern: RequestPattern::StrictSpatial,
+        }];
+
+        core.create_video_filter(
+            output,
+            cstr!("Depth"),
+            &vi,
+            Box::new(filter),
+            Dependencies::new(&deps).unwrap(),
+        );
+
+        Ok(())
+    }
+
+    fn get_frame(
+        &self,
+        n: i32,
+        activation_reason: ActivationReason,
+        _frame_data: *mut *mut c_void,
+        mut ctx: FrameContext,
+        core: CoreRef,
+    ) -> Result<Option<VideoFrame>, Self::Error> {
+        use ActivationReason as r;
+
+        match activation_reason {
+            r::Initial => {
+                ctx.request_frame_filter(n, &self.node);
+            }
+            r::AllFramesReady => {
+                let src = self.node.get_frame_filter(n, &mut ctx);
+                let dst = core.copy_frame(&src);
+
+                // Do whatever frame processing here, in the new bit depth.
+
+                return Ok(Some(dst));
+            }
+            _ => {}
+        }
+
+        Ok(None)
+    }
+
+    const NAME: &'static CStr = cstr!("Depth");
+    const ARGS: &'static CStr = cstr!("clip:vnode;bits:int:opt;");
+    const RETURN_TYPE: &'static CStr = cstr!("clip:vnode;");
+}

--- a/sample-plugin/src/lib.rs
+++ b/sample-plugin/src/lib.rs
@@ -1,12 +1,15 @@
+mod dither;
+
 use std::ffi::{c_void, CStr};
 
 use const_str::cstr;
+use dither::DitherFilter;
 use vapoursynth4_rs::{
     core::CoreRef,
     declare_plugin,
     frame::{FrameContext, VideoFrame},
     key,
-    map::{MapMut, MapRef},
+    map::MapRef,
     node::{
         ActivationReason, Dependencies, Filter, FilterDependency, Node, RequestPattern, VideoNode,
     },
@@ -24,8 +27,8 @@ impl Filter for DumbFilter {
     type FilterData = ();
 
     fn create(
-        input: MapRef<'_>,
-        output: MapMut<'_>,
+        input: &MapRef,
+        output: &mut MapRef,
         _data: Option<Box<Self::FilterData>>,
         mut core: CoreRef,
     ) -> Result<(), Self::Error> {
@@ -132,5 +135,6 @@ declare_plugin!(
     (1, 0),
     vapoursynth4_rs::VAPOURSYNTH_API_VERSION,
     0,
-    (DumbFilter, None)
+    (DumbFilter, None),
+    (DitherFilter, None)
 );

--- a/vapoursynth4-rs/src/core.rs
+++ b/vapoursynth4-rs/src/core.rs
@@ -17,7 +17,7 @@ use crate::{
     ffi,
     frame::{AudioFormat, AudioFrame, Frame, VideoFormat, VideoFrame},
     function::Function,
-    map::MapMut,
+    map::MapRef,
     node::{internal::FilterExtern, Dependencies, Filter},
     plugin::{Plugin, Plugins},
     AudioInfo, ColorFamily, SampleType, VideoInfo,
@@ -105,15 +105,16 @@ impl Core {
     /// Panic if the `dependencies` has more item than [`i32::MAX`]
     pub fn create_video_filter<F: Filter>(
         &mut self,
-        mut out: MapMut<'_>,
+        out: &mut MapRef,
         name: &CStr,
         info: &VideoInfo,
         filter: Box<F>,
         dependencies: &Dependencies,
     ) {
+        debug_assert!(!out.as_ptr().is_null());
         unsafe {
             (api().createVideoFilter)(
-                (*out).as_mut_ptr(),
+                out.as_mut_ptr(),
                 name.as_ptr(),
                 info,
                 F::filter_get_frame,
@@ -132,7 +133,7 @@ impl Core {
     /// Panic if the `dependencies` has more item than [`i32::MAX`]
     pub fn create_audio_filter<F: Filter>(
         &mut self,
-        mut out: MapMut<'_>,
+        out: &mut MapRef,
         name: &CStr,
         info: &AudioInfo,
         filter: F,

--- a/vapoursynth4-rs/src/frame.rs
+++ b/vapoursynth4-rs/src/frame.rs
@@ -6,11 +6,7 @@
 
 use std::ptr::NonNull;
 
-use crate::{
-    api::api,
-    ffi,
-    map::{MapMut, MapRef},
-};
+use crate::{api::api, ffi, map::MapRef};
 
 mod context;
 mod format;
@@ -26,18 +22,18 @@ pub trait Frame: Sized + internal::FrameFromPtr {
     fn as_mut_ptr(&mut self) -> *mut ffi::VSFrame;
 
     #[must_use]
-    fn properties(&self) -> Option<MapRef<'_>> {
+    fn properties(&self) -> Option<&MapRef> {
         unsafe {
             let ptr = (api().getFramePropertiesRO)(self.as_ptr());
-            NonNull::new(ptr.cast_mut()).map(MapRef::new)
+            NonNull::new(ptr.cast_mut()).map(|x| MapRef::from_ptr(x.as_ptr()))
         }
     }
 
     #[must_use]
-    fn properties_mut(&mut self) -> Option<MapMut<'_>> {
+    fn properties_mut(&mut self) -> Option<&mut MapRef> {
         unsafe {
             let ptr = (api().getFramePropertiesRW)(self.as_mut_ptr());
-            NonNull::new(ptr).map(MapMut::new)
+            NonNull::new(ptr).map(|x| MapRef::from_ptr_mut(x.as_ptr()))
         }
     }
 }

--- a/vapoursynth4-rs/src/node/filter.rs
+++ b/vapoursynth4-rs/src/node/filter.rs
@@ -7,7 +7,7 @@ use crate::{
     core::CoreRef,
     ffi,
     frame::{Frame, FrameContext},
-    map::{MapMut, MapRef},
+    map::MapRef,
     node::FilterMode,
 };
 
@@ -30,8 +30,8 @@ where
     /// Return [`Self::Error`] if anything happens during the filter creation.
     /// The error message will be passed to `VapourSynth`.
     fn create(
-        input: MapRef<'_>,
-        output: MapMut<'_>,
+        input: &MapRef,
+        output: &mut MapRef,
         data: Option<Box<Self::FilterData>>,
         core: CoreRef,
     ) -> Result<(), Self::Error>;

--- a/vapoursynth4-rs/src/node/internal.rs
+++ b/vapoursynth4-rs/src/node/internal.rs
@@ -9,7 +9,7 @@ use crate::{
     api::API,
     core::CoreRef,
     frame::{Frame, FrameContext},
-    map::{MapMut, MapRef},
+    map::MapRef,
     utils::ToCString,
 };
 
@@ -26,7 +26,7 @@ pub trait FilterExtern: Filter {
         API.set(vsapi);
 
         let input = MapRef::from_ptr(in_);
-        let mut output = MapMut::from_ptr(out);
+        let output = MapRef::from_ptr_mut(out);
         let core = CoreRef::from_ptr(core);
         let data = if user_data.is_null() {
             None

--- a/vapoursynth4-rs/src/plugin.rs
+++ b/vapoursynth4-rs/src/plugin.rs
@@ -54,7 +54,8 @@ impl Plugin {
     }
 
     #[must_use]
-    pub fn invoke(&self, name: &CStr, args: MapRef<'_>) -> Map {
+    pub fn invoke(&self, name: &CStr, args: &MapRef) -> Map {
+        debug_assert!(!args.as_ptr().is_null());
         unsafe {
             let ptr = (api().invoke)(self.as_ptr().cast_mut(), name.as_ptr(), args.as_ptr());
             Map::from_ptr(ptr)


### PR DESCRIPTION
I wanted to use `Plugin.invoke()` to call another plugin, but found that it required a `MapRef<'_>` and there wasn't an ergonomic way to dereference a `Map` into a `MapRef`. The only way I saw to get a `MapRef` was to do:

```rust
let mut args = Map::new();
// [set args]
let args_ref = NonNull::new(args.as_mut_ptr()).map(MapRef::new).unwrap();
plugin.invoke(cstr!("Filter"), args_ref);
```

To make this easier, I refactored `Map`, `MapMut`, and `MapRef` into just `Map` and `MapRef`, with implementations for `AsRef`, `Borrow`, `Deref`, etc. The same general pattern is still here, with one type being an owned map and the other being a borrowed one, but there's one less type now and no explicit lifetimes. Methods that did not require ownership of the map have been moved to `MapRef`.

Now the above code can be written as:

```rust
let mut args = Map::new();
// [set args]
plugin.invoke(cstr!("Filter"), &args);
```

Also added a second sample filter to the sample plugin to demonstrate it.