### PR TITLE
fix: put links behind the link-library feature flag

### DIFF
--- a/vapoursynth4-sys/src/vs.rs
+++ b/vapoursynth4-sys/src/vs.rs
@@ -2205,6 +2205,7 @@ pub struct VSAPI {
         unsafe extern "system-unwind" fn(node: *mut VSNode, level: c_int) -> *const VSMap,
 }
 
+#[cfg(feature = "link-library")]
 #[link(name = "vapoursynth")]
 unsafe extern "system-unwind" {
     /// Returns a pointer to the global [`VSAPI`] instance.

--- a/vapoursynth4-sys/src/vsscript.rs
+++ b/vapoursynth4-sys/src/vsscript.rs
@@ -225,6 +225,7 @@ pub struct VSSCRIPTAPI {
     ) -> c_int,
 }
 
+#[cfg(feature = "link-library")]
 #[cfg_attr(target_os = "windows", link(name = "VSScript"))]
 #[cfg_attr(not(target_os = "windows"), link(name = "vapoursynth-script"))]
 unsafe extern "system-unwind" {


### PR DESCRIPTION
Was previously handled by `vapoursynth4-sys/build.rs`, but got split out in 15ffab3.