### PR TITLE
Add feature flags to vapoursynth4-rs that propagate to vapoursynth4-sys

### DIFF
--- a/vapoursynth4-rs/Cargo.toml
+++ b/vapoursynth4-rs/Cargo.toml
@@ -20,7 +20,13 @@ const-str = "0.7.0"
 testresult = "0.4.1"
 
 [features]
+default = ["vs-41", "vsscript", "vsscript-42"]
 link-library = ["vapoursynth4-sys/link-library"]
+vs-41 = ["vapoursynth4-sys/vs-41"]
+vsscript = ["vapoursynth4-sys/vsscript"]
+vsscript-42 = ["vapoursynth4-sys/vsscript-42"]
+vs-graph = ["vapoursynth4-sys/vs-graph"]
+
 # default = ["macros"]
 # macros = ["vapoursynth4-rs-macros"]
 

--- a/vapoursynth4-rs/README.md
+++ b/vapoursynth4-rs/README.md
@@ -26,9 +26,9 @@ All VapourSynth and VSScript API versions starting with 4.0 are supported.
 By default, the crates use the latest API version available.  To use a specific version,
 disable the default feature and enable the corresponding Cargo feature:
 
-- `vapoursynth-api-40` for VapourSynth API 4.0 (R55)
-- `vsscript-api-40` for VSScript API 4.0
-- `vsscript-api-41` for VSScript API 4.1
+- `vs-41` for VapourSynth API 4.1 (R66)
+- `vsscript` for VSScript API 4.0
+- `vsscript-42` for VSScript API 4.1
 
 ## Building
 

--- a/vapoursynth4-sys/Cargo.toml
+++ b/vapoursynth4-sys/Cargo.toml
@@ -25,7 +25,7 @@ vs-graph = []
 # Link the VapourSynth library
 link-library = []
 
-default = ["vs-41", "vsscript", "vsscript-42"]
+default = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/vapoursynth4-sys/README.md
+++ b/vapoursynth4-sys/README.md
@@ -17,12 +17,11 @@ Check out [vapoursynth4-rs](https://crates.io/crates/vapoursynth4-rs) for a safe
 ## Supported Versions
 
 All VapourSynth and VSScript API versions starting with 4.0 are supported.
-By default, the crates use the latest API version available.  To use a specific version,
-disable the default feature and enable the corresponding Cargo feature:
+By default, the crates use the VapourSynth API 4.0 API.  To use a specific version, enable the corresponding Cargo feature:
 
-- `vapoursynth-api-40` for VapourSynth API 4.0 (R55)
-- `vsscript-api-40` for VSScript API 4.0
-- `vsscript-api-41` for VSScript API 4.1
+- `vs-41` for VapourSynth API 4.1 (R66)
+- `vsscript` for VSScript API 4.0
+- `vsscript-42` for VSScript API 4.1
 
 ## Building
 


### PR DESCRIPTION
As Cargo's features are additive (you cannot disable default from the wrapper (vs-rs) to the core (vs-sys)), its better to set the default from the wrapper.